### PR TITLE
fix null element appearing at app initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 angular.module('uctc',[]);
 
 angular.module('uctc').controller('homeCtrl',function($scope, totalFactory, constants){
-  $scope.rows = [{}];
+  $scope.rows = [];
   $scope.source = constants.source;
   $scope.lastUpdate = constants.lastUpdate;
 


### PR DESCRIPTION
I think a bit is missing from one of the previous merge procedures. The fix is quite simple though, the rows array should be empty.